### PR TITLE
Use master for CI builds, skip 4.0.0.GA download, use ti build CMD's to build modules

### DIFF
--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Argument = -sdk 3.1.2.GA
+# Argument = -sdk 6.0.1.GA
 OPTIND=1    # also remember to initialize your flags and other variables
 
 usage()
@@ -11,12 +11,12 @@ Installs various pre-requisites for building a module.
 
 OPTIONS:
    -h      Show this message
-   -s      Version of Titanium SDK to use. If not specified, uses 5.3.0.GA
+   -s      Version of Titanium SDK to use. If not specified, uses 6.0.1.GA
    -a      Version of Android SDK to install. If not specified, uses 23
 EOF
 }
 
-export TITANIUM_SDK_VERSION="5.3.0.GA"
+export TITANIUM_SDK_VERSION="6.0.1.GA"
 export TITANIUM_ANDROID_API="23"
 while getopts ":h:s:a:" OPTION
 do

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -44,11 +44,7 @@ brew install jq # process JSON
 
 sudo npm install -g titanium
 titanium login travisci@appcelerator.com travisci
-
-# Android SDK seems to require newer version of SDK
-echo
-echo "Installing $TITANIUM_SDK_VERSION"
-echo
+titanium sdk install -b master --no-progress-bars
 
 export TITANIUM_ROOT=`ti sdk list -o json | jq -r '.defaultInstallLocation'`
 export TITANIUM_SDK=`ti sdk list -o json | jq -r '.installed[.activeSDK]'`

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -50,7 +50,6 @@ titanium sdk install latest --no-progress-bars
 echo
 echo "Installing $TITANIUM_SDK_VERSION"
 echo
-titanium sdk install -d $TITANIUM_SDK_VERSION --no-progress-bars
 
 export TITANIUM_ROOT=`ti sdk list -o json | jq -r '.defaultInstallLocation'`
 export TITANIUM_SDK=`ti sdk list -o json | jq -r '.installed[.activeSDK]'`

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -44,7 +44,6 @@ brew install jq # process JSON
 
 sudo npm install -g titanium
 titanium login travisci@appcelerator.com travisci
-titanium sdk install latest --no-progress-bars
 
 # Android SDK seems to require newer version of SDK
 echo

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -5,7 +5,7 @@ STATUS=0
 
 # IF top-level build file, run that
 if [ -e "$MODULE_ROOT/build.sh" ]; then
-	./build.sh
+	ti build -p ios --build-only
 else
 	# If iOS module exists, build
 	if [ -d "$MODULE_ROOT/ios/" ]; then
@@ -17,7 +17,7 @@ else
 		cd $MODULE_ROOT/ios/
 		cp $MODULE_ROOT/titanium.xcconfig titanium.xcconfig
 		cat titanium.xcconfig
-		./build.py
+		ti build -p ios --build-only
 
 		let STATUS=$?
 		if (( "$RETSTATUS" == "0" )) && (( "$STATUS" != "0" )); then

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -91,7 +91,7 @@ else
 	  mkdir -p build/docs
 
 	  ant clean
-	  ant
+	  ti build -p android --build-only
 
 	  let STATUS=$?
 	  if (( "$RETSTATUS" == "0" )) && (( "$STATUS" != "0" )); then


### PR DESCRIPTION
This is a proposal I recently used in my fork to validate my modules (e.g. ti.bluetooth, ti.googlemaps and ti.wkwebview). It replaces the 4.0.0.GA download with downloading the latest master build, replaces the python- and ant-calls with our `ti build -p [ios|android] --build-only` and defaults `TITANIUM_SDK_VERSION ` from 5.3.0.GA to 6.0.1.GA. 

I am sure the scripts have their purpose, so this is open for discussion. If accepted, we may consider to merge it to the appcelerator (master) repo as well and change the affected .travis files to those one for a centralized solution. Thx!